### PR TITLE
Bump LICENSE year from 2022 to 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Devon Powell
+Copyright (c) 2023 Devon Powell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Bump LICENSE year from 2022 to 2023.